### PR TITLE
rsync: add SSL/TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Provides:
 
 * nginx service for serving installers and packages (ports 80 and 443)
-* rsync server for serving the same (port 873)
+* rsync server for serving the same (port 873, and 874 with SSL)
 * daemon and http server for staging repositories
 * letsencrypt integration
 * packages web interface and API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - "--providers.file.directory=/configs/"
       - "--entrypoints.rsync.address=:873"
       - "--entryPoints.rsync.transport.respondingTimeouts.readTimeout=0"
+      - "--entrypoints.rsync-ssl.address=:874"
+      - "--entryPoints.rsync-ssl.transport.respondingTimeouts.readTimeout=0"
       - "--entryPoints.web.address=:80"
       - "--entryPoints.web-secure.address=:443"
       - "--certificatesResolvers.le.acme.email=david.macek.0@gmail.com"
@@ -57,6 +59,7 @@ services:
       - "443:443/tcp"
       - "443:443/udp"
       - "873:873"
+      - "874:874"
       # - "8080:8080" # for debug interface on 8080
     volumes:
       - ./services/reverse-proxy/traefik-tls.yml:/configs/traefik-tls.yml:ro
@@ -234,6 +237,11 @@ services:
       - "traefik.enable=true"
       - "traefik.tcp.routers.rsync.rule=HostSNI(`*`)"
       - "traefik.tcp.routers.rsync.entrypoints=rsync"
+      - "traefik.tcp.routers.rsync-ssl.rule=HostSNI(`repo.msys2.org`)"
+      - "traefik.tcp.routers.rsync-ssl.entrypoints=rsync-ssl"
+      - "traefik.tcp.routers.rsync-ssl.tls=true"
+      - "traefik.tcp.routers.rsync-ssl.tls.certresolver=le"
+      - "traefik.tcp.services.rsync.loadbalancer.server.port=873"
     restart: unless-stopped
 
   redis:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,6 +23,15 @@ class TestServer(unittest.TestCase):
         self.assertTrue("mingw" in out)
         self.assertTrue("msys" in out)
 
+    def test_rsync_ssl(self):
+        out = subprocess.check_output(
+            ["rsync-ssl", "--list-only", "rsync://repo.msys2.org/builds/"],
+            universal_newlines=True,
+            timeout=self.TIMEOUT)
+        self.assertTrue("distrib" in out)
+        self.assertTrue("mingw" in out)
+        self.assertTrue("msys" in out)
+
     def test_repo(self):
         with urlopen("https://repo.msys2.org", timeout=self.TIMEOUT) as r:
             self.assertEqual(r.url, "https://repo.msys2.org")


### PR DESCRIPTION
Add TLS to rsync and expose on port 874.

Connect to it via "rsync-ssl rsync://repo.msys2.org"

For more info see "man rsync-ssl"