### PR TITLE
repo,mirrorbits: add HTTP redirects for old mingw/(i686,x86_64) directories

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -110,9 +110,14 @@ services:
       - "traefik.enable=true"
       - "traefik.http.services.repo.loadbalancer.server.port=80"
       - "traefik.docker.network=msys2-repo-dev_repo"
+      - "traefik.http.middlewares.repo-legacy-mingw32-redir.redirectregex.regex=^http(s?)://([^/]*)/mingw/i686($$|/.*)"
+      - "traefik.http.middlewares.repo-legacy-mingw32-redir.redirectregex.replacement=http$${1}://$${2}/mingw/mingw32$${3}"
+      - "traefik.http.middlewares.repo-legacy-mingw64-redir.redirectregex.regex=^http(s?)://([^/]*)/mingw/x86_64($$|/.*)"
+      - "traefik.http.middlewares.repo-legacy-mingw64-redir.redirectregex.replacement=http$${1}://$${2}/mingw/mingw64$${3}"
       # http
       - "traefik.http.routers.repo.rule=Host(`repo.localhost`)"
       - "traefik.http.routers.repo.entrypoints=web"
+      - "traefik.http.routers.repo.middlewares=repo-legacy-mingw32-redir,repo-legacy-mingw64-redir"
     restart: unless-stopped
 
   staging:
@@ -216,9 +221,14 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=msys2-repo-dev_mirrorbits"
+      - "traefik.http.middlewares.mirrorbits-legacy-mingw32-redir.redirectregex.regex=^http(s?)://([^/]*)/mingw/i686($$|/.*)"
+      - "traefik.http.middlewares.mirrorbits-legacy-mingw32-redir.redirectregex.replacement=http$${1}://$${2}/mingw/mingw32$${3}"
+      - "traefik.http.middlewares.mirrorbits-legacy-mingw64-redir.redirectregex.regex=^http(s?)://([^/]*)/mingw/x86_64($$|/.*)"
+      - "traefik.http.middlewares.mirrorbits-legacy-mingw64-redir.redirectregex.replacement=http$${1}://$${2}/mingw/mingw64$${3}"
       # http
       - "traefik.http.routers.mirrorbits.rule=Host(`mirror.localhost`)"
       - "traefik.http.routers.mirrorbits.entrypoints=web"
+      - "traefik.http.routers.mirrorbits.middlewares=mirrorbits-legacy-mingw32-redir,mirrorbits-legacy-mingw64-redir"
 
 volumes:
   staging-gnupg:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,10 @@ services:
       - "traefik.docker.network=msys2-repo_repo"
       - "traefik.http.middlewares.repo-scheme-redir.redirectscheme.scheme=https"
       - "traefik.http.middlewares.repo-headers.headers.stsseconds=31536000"
+      - "traefik.http.middlewares.repo-legacy-mingw32-redir.redirectregex.regex=^http(s?)://([^/]*)/mingw/i686($$|/.*)"
+      - "traefik.http.middlewares.repo-legacy-mingw32-redir.redirectregex.replacement=http$${1}://$${2}/mingw/mingw32$${3}"
+      - "traefik.http.middlewares.repo-legacy-mingw64-redir.redirectregex.regex=^http(s?)://([^/]*)/mingw/x86_64($$|/.*)"
+      - "traefik.http.middlewares.repo-legacy-mingw64-redir.redirectregex.replacement=http$${1}://$${2}/mingw/mingw64$${3}"
       # http
       - "traefik.http.routers.repo.rule=Host(`repo.msys2.org`)"
       - "traefik.http.routers.repo.middlewares=repo-scheme-redir"
@@ -202,7 +206,7 @@ services:
       - "traefik.http.routers.repo-secure.rule=Host(`repo.msys2.org`)"
       - "traefik.http.routers.repo-secure.tls=true"
       - "traefik.http.routers.repo-secure.tls.certresolver=le"
-      - "traefik.http.routers.repo-secure.middlewares=repo-headers"
+      - "traefik.http.routers.repo-secure.middlewares=repo-headers,repo-legacy-mingw32-redir,repo-legacy-mingw64-redir"
       - "traefik.http.routers.repo-secure.entrypoints=web-secure"
     restart: unless-stopped
 
@@ -321,6 +325,10 @@ services:
       - "traefik.docker.network=msys2-repo_mirrorbits"
       - "traefik.http.middlewares.mirrorbits-scheme-redir.redirectscheme.scheme=https"
       - "traefik.http.middlewares.mirrorbits-headers.headers.stsseconds=31536000"
+      - "traefik.http.middlewares.mirrorbits-legacy-mingw32-redir.redirectregex.regex=^http(s?)://([^/]*)/mingw/i686($$|/.*)"
+      - "traefik.http.middlewares.mirrorbits-legacy-mingw32-redir.redirectregex.replacement=http$${1}://$${2}/mingw/mingw32$${3}"
+      - "traefik.http.middlewares.mirrorbits-legacy-mingw64-redir.redirectregex.regex=^http(s?)://([^/]*)/mingw/x86_64($$|/.*)"
+      - "traefik.http.middlewares.mirrorbits-legacy-mingw64-redir.redirectregex.replacement=http$${1}://$${2}/mingw/mingw64$${3}"
       # http
       - "traefik.http.routers.mirrorbits.rule=Host(`mirror.msys2.org`)"
       - "traefik.http.routers.mirrorbits.entrypoints=web"
@@ -329,7 +337,7 @@ services:
       - "traefik.http.routers.mirrorbits-secure.rule=Host(`mirror.msys2.org`)"
       - "traefik.http.routers.mirrorbits-secure.tls=true"
       - "traefik.http.routers.mirrorbits-secure.tls.certresolver=le"
-      - "traefik.http.routers.mirrorbits-secure.middlewares=mirrorbits-headers"
+      - "traefik.http.routers.mirrorbits-secure.middlewares=mirrorbits-headers,mirrorbits-legacy-mingw32-redir,mirrorbits-legacy-mingw64-redir"
       - "traefik.http.routers.mirrorbits-secure.entrypoints=web-secure"
 
   autobuild-controller:


### PR DESCRIPTION
Many years ago we switched to a the directory structure matching the repo names, to simplify the pacman repo config, see
https://github.com/msys2/MSYS2-packages/commit/cfdb662d9859a21174afa3c9c3d1eb9ec1d98727 For backwards compat we added symlinks for the old names back then, so the old paths would continue to work.

The duplication there has lead to confusion though, as it's not clear why some repos are duplicated, and if there is a difference between them.

Quite some time has passed now, but according to the logs there are still some (outdated) systems accessing the old paths.

Since it's not that hard, add a HTTP redirect for them. This means, once we remove the symlinks, those paths will stop working on the mirrors but continue to work on the main repo at least.